### PR TITLE
Fix a typo in position_at

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ where
 
 			let h05 = h_5(t, 0);
 			let h15 = h_5(t, 1);
-			let h25 = h_5(t, 1);
+			let h25 = h_5(t, 2);
 			let h35 = h_5(t, 3);
 			let h45 = h_5(t, 4);
 			let h55 = h_5(t, 5);


### PR DESCRIPTION
I was wondering what was going on!  Now, we use the second hermite basis function instead of the first for acceleration.

Closes #21.